### PR TITLE
Distance Sensor on Claw

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -173,6 +173,7 @@ public final class Constants {
 
   public static class ClawConstants {
     public static double openingDelay = 0.25;
+    public static int threshholdObjectDistance = 8;
   }
 
   public static abstract class FieldConstants {

--- a/src/main/java/frc/robot/commands/claw/CloseOnObject.java
+++ b/src/main/java/frc/robot/commands/claw/CloseOnObject.java
@@ -1,0 +1,49 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.claw;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants.ClawConstants;
+import frc.robot.subsystems.Claw;
+import frc.robot.subsystems.Claw.ClawMode;
+
+public class CloseOnObject extends CommandBase {
+  /** Creates a new CloseOnObject. */
+  private Claw claw;
+
+  /**
+   * Creates a new command that waits for an object to enter the claw, before
+   * closing the claw and ending the command.
+   * 
+   * @param claw Claw object to use in the command.
+   */
+  public CloseOnObject(Claw claw) {
+    this.claw = claw;
+    addRequirements(this.claw);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    this.claw.setClawMode(ClawMode.open);
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    this.claw.setClawMode(ClawMode.closed);
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return this.claw.getDistanceFromClaw() < ClawConstants.threshholdObjectDistance;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/Claw.java
+++ b/src/main/java/frc/robot/subsystems/Claw.java
@@ -4,15 +4,18 @@
 
 package frc.robot.subsystems;
 
+import com.revrobotics.ColorSensorV3;
 import edu.wpi.first.wpilibj.DoubleSolenoid;
 import edu.wpi.first.wpilibj.PneumaticsModuleType;
 import edu.wpi.first.wpilibj.DoubleSolenoid.Value;
+import edu.wpi.first.wpilibj.I2C.Port;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.DeviceIds;
 
 public class Claw extends SubsystemBase {
   /** Creates a new Claw. */
   private DoubleSolenoid actuator;
+  private ColorSensorV3 colorSensor;
 
   /**
    * Creates a new claw object with a double solenoid and color sensor.
@@ -22,6 +25,7 @@ public class Claw extends SubsystemBase {
         PneumaticsModuleType.CTREPCM,
         DeviceIds.clawForward,
         DeviceIds.clawReverse);
+    this.colorSensor = new ColorSensorV3(Port.kOnboard);
   }
 
   /**
@@ -38,6 +42,15 @@ public class Claw extends SubsystemBase {
         this.actuator.set(Value.kForward);
         break;
     }
+  }
+
+  /**
+   * Method returns how far away from the claw an object is.
+   * 
+   * @return Distance away from the claw in centimeters. Between 1cm and 10cm.
+   */
+  public int getDistanceFromClaw() {
+    return this.colorSensor.getProximity();
   }
 
   @Override


### PR DESCRIPTION
This pr closes #4.

The original plan was to use an analog ultrasonic sensor to measure distance, but I noticed that we had a [Rev Color Sensor](https://docs.revrobotics.com/color-sensor/) which doubles as a distance sensor. 

Using it achieves the same intended functionality, just at a lower cost and with fewer lines of code.
